### PR TITLE
remove group with potentially unknown programs

### DIFF
--- a/etc/supervisord.conf
+++ b/etc/supervisord.conf
@@ -79,6 +79,3 @@ stderr_logfile = NONE
 
 [group:policycompass]
 programs = policycompass-frontend, policycompass-services, elasticsearch, tomcat, postgres
-
-[group:adhocracygrp]
-programs = zeo, autobahn, adhocracy, adhocracy_frontend


### PR DESCRIPTION
- this group should only be used if adhocracy was build
