### PR TITLE
introduce default server with redirect to frontend

### DIFF
--- a/etc/nginx.conf
+++ b/etc/nginx.conf
@@ -12,6 +12,14 @@ events {
 http {
   access_log off;
 
+  # for all non-matching server names redirect to frontend-dev
+  server {
+    listen 1080 default_server;
+    location / {
+       return 301 $scheme://frontend-dev.policycompass.eu;
+    }
+  }
+
   server {
     listen 1080;
     server_name services-dev.policycompass.eu;


### PR DESCRIPTION
- create default host that redirects to proper frontend
- makes site available under policompass.eu and policycompass.liqd.net
- redirects automatically if wrong hostname was used
