### PR TITLE
Expose carneades through nginx

### DIFF
--- a/etc/nginx.conf
+++ b/etc/nginx.conf
@@ -97,4 +97,14 @@ http {
       proxy_set_header   X-Real-IP        $remote_addr;
     }
   }
+
+  server {
+    listen 1080;
+    server_name carneades-dev.policycompass.eu;
+    location / {
+      proxy_pass http://localhost:10080;
+      proxy_set_header   Host             $host;
+      proxy_set_header   X-Real-IP        $remote_addr;
+    }
+  }
 }


### PR DESCRIPTION
I'm not sure whether we actually want to proxy to `/carneades/` - the
default entry path seems to be `/carneades/#/projects`.

@pallix - how would you deploy / proxy it? It has a separate domain, i.e. https://carneades-dev.policycompass.eu - so the path can be selected completely freely.
