### PR TITLE
Set adhocracy as embed_only

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -11,7 +11,7 @@ POSTGRES_EXECUTABLE=$(POSTGRES_BIN_PATH)/postgres
 # python executable used by node-gyp
 GYPPYTHON_EXECUTABLE=$(shell which python2)
 
-ADHOCRACY3_COMMIT="89dade159f1fbdd9ed6bee48692fa008667084d1"
+ADHOCRACY3_COMMIT="067a980e23e2e2ec9fa7a844bfecf4b649acdb85"
 
 # support different config files for different environments
 ifeq ($(shell hostname),poco-test)

--- a/etc/adhocracy/dev/frontend_development.ini
+++ b/etc/adhocracy/dev/frontend_development.ini
@@ -1,8 +1,3 @@
-#
-# WARNING: Please make you changes in *.ini.in file and then run buildout
-#          to install it.
-#
-
 [app:main]
 use = egg:pcompass
 

--- a/etc/adhocracy/dev/frontend_development.ini
+++ b/etc/adhocracy/dev/frontend_development.ini
@@ -60,7 +60,7 @@ adhocracy.custom = mercator_platform_path financial_plan_url_de financial_plan_u
 adhocracy.custom.mercator_platform_path = /mercator/
 adhocracy.custom.show_add_button = true
 adhocracy.custom.allow_rate = true
-adhocracy.custom.embed_only = false
+adhocracy.custom.embed_only = true
 
 cachebust.enabled = false
 cachebust.method = init

--- a/etc/adhocracy/prod/frontend_development.ini
+++ b/etc/adhocracy/prod/frontend_development.ini
@@ -1,8 +1,3 @@
-#
-# WARNING: Please make you changes in *.ini.in file and then run buildout
-#          to install it.
-#
-
 [app:main]
 use = egg:pcompass
 

--- a/etc/adhocracy/prod/frontend_development.ini
+++ b/etc/adhocracy/prod/frontend_development.ini
@@ -57,10 +57,11 @@ adhocracy.trusted_domains =
 #     http://localhost:9000
 #     http://localhost:9001
 
-adhocracy.custom = mercator_platform_path financial_plan_url_de financial_plan_url_en show_add_button allow_rate
+adhocracy.custom = mercator_platform_path financial_plan_url_de financial_plan_url_en show_add_button allow_rate embed_only
 adhocracy.custom.mercator_platform_path = /mercator/
 adhocracy.custom.show_add_button = true
 adhocracy.custom.allow_rate = true
+adhocracy.custom.embed_only = true
 
 cachebust.enabled = false
 cachebust.method = init

--- a/etc/adhocracy/stage/frontend_development.ini
+++ b/etc/adhocracy/stage/frontend_development.ini
@@ -57,10 +57,11 @@ adhocracy.trusted_domains =
 #     http://localhost:9000
 #     http://localhost:9001
 
-adhocracy.custom = mercator_platform_path financial_plan_url_de financial_plan_url_en show_add_button allow_rate
+adhocracy.custom = mercator_platform_path financial_plan_url_de financial_plan_url_en show_add_button allow_rate embed_only
 adhocracy.custom.mercator_platform_path = /mercator/
 adhocracy.custom.show_add_button = true
 adhocracy.custom.allow_rate = true
+adhocracy.custom.embed_only = true
 
 cachebust.enabled = false
 cachebust.method = init


### PR DESCRIPTION
This option assumes there is no "full adhocracy platform" installed,
i.e. adhocracy is always embedded.

This in particular changes the way a user is guided after clicking on
the activation link after registration.