### PR TITLE
Remove unneeded leiningen dependency (fixes #206)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -35,8 +35,8 @@ install_deps: install_deps_ubuntu install_elasticsearch_ubuntu /usr/bin/node
 # list of packages for ubuntu 14.04 lts
 UBUNTU_PACKAGES= maven tomcat7 libxml2 libxslt1.1 libzip2 python3 python3-pil python3-pip		\
 	         python-virtualenv python3-ipdb python3-pep8 pyflakes sqlite build-essential zlibc	\
-	         curl file git ruby ruby-dev nodejs npm leiningen openjdk-7-jdk phantomjs		\
-	         supervisor nginx postgresql
+	         curl file git ruby ruby-dev nodejs npm openjdk-7-jdk phantomjs supervisor nginx    \
+			 postgresql
 
 /usr/bin/node:
 	ln -sfT /usr/bin/nodejs /usr/bin/node


### PR DESCRIPTION
Carneades 3 is installed with manually installed leiningen anyway.