### PR TITLE
Proper Adhocracy site_name in sample backend configs

### DIFF
--- a/etc/adhocracy/dev/development.ini
+++ b/etc/adhocracy/dev/development.ini
@@ -43,7 +43,7 @@ adhocracy.validate_user_token = true
 #adhocracy.varnish_url = http://127.0.0.1:8088
 
 # Name of the entire site. Used in account registration information etc.
-adhocracy.site_name = Adhocracy Test Site
+adhocracy.site_name = Policy Compass - Development
 
 # Canonical frontend base URL. If this is an embedding URL, it should end with
 # #!. This is used for the creation of activation links.

--- a/etc/adhocracy/prod/development.ini
+++ b/etc/adhocracy/prod/development.ini
@@ -43,7 +43,7 @@ adhocracy.skip_registration_mail = false
 #adhocracy.varnish_url = http://127.0.0.1:8088
 
 # Name of the entire site. Used in account registration information etc.
-adhocracy.site_name = Adhocracy Test Site
+adhocracy.site_name = Policy Compass
 
 # Canonical frontend base URL. If this is an embedding URL, it should end with
 # #!. This is used for the creation of activation links.

--- a/etc/adhocracy/stage/development.ini
+++ b/etc/adhocracy/stage/development.ini
@@ -38,7 +38,7 @@ adhocracy.skip_registration_mail = false
 #adhocracy.varnish_url = http://127.0.0.1:8088
 
 # Name of the entire site. Used in account registration information etc.
-adhocracy.site_name = Adhocracy Test Site
+adhocracy.site_name = Policy Compass - Staging
 
 # Canonical frontend base URL. If this is an embedding URL, it should end with
 # #!. This is used for the creation of activation links.


### PR DESCRIPTION
Same as 40129a6d7d61, but for backend configs