### PR TITLE
Disable elasticsearch cluster

### DIFF
--- a/etc/elasticsearch/elasticsearch.yml
+++ b/etc/elasticsearch/elasticsearch.yml
@@ -389,3 +389,7 @@ node.name: "policycompass-es-node1"
 http.cors.enabled: true
 http.cors.allow-headers: X-Requested-With, Content-Type, Content-Length, Authorization, X-User-Path, X-User-Token
 http.cors.allow-origin: "*"
+
+# Disable cluster
+
+node.local: true


### PR DESCRIPTION
We were *very* confused when I suddenly had @slomo's test data in my
local policycompass installation...

In my opinion such a feature should be deliberately *enabled*, not *disabled*.