### PR TITLE
Adhocracy frontend on staging should trust localhost:9000

### DIFF
--- a/etc/adhocracy/stage/frontend_development.ini
+++ b/etc/adhocracy/stage/frontend_development.ini
@@ -54,8 +54,8 @@ adhocracy.canonical_url = https://adhocracy-frontend-stage.policycompass.eu
 # Adhocracy may pass user authentication token to the embedding website.
 adhocracy.trusted_domains =
     https://frontend-stage.policycompass.eu
-#     http://localhost:9000
-#     http://localhost:9001
+    http://localhost:9000
+#    http://localhost:9001
 
 adhocracy.custom = mercator_platform_path financial_plan_url_de financial_plan_url_en show_add_button allow_rate embed_only
 adhocracy.custom.mercator_platform_path = /mercator/


### PR DESCRIPTION
This allows to use the staging adhocracy server from a typical
policycompass development environment.