### PR TITLE
Set correct adhocracy URL in settings

### DIFF
--- a/etc/policycompass/prod/services-settings.py
+++ b/etc/policycompass/prod/services-settings.py
@@ -38,7 +38,7 @@ PC_SERVICES = {
         'updateindexitem' : '/api/v1/searchmanager/updateindexitem',
         'deleteindexitem' : '/api/v1/searchmanager/deleteindexitem',
         'fcm_base_url': 'http://localhost:10080',
-        'adhocracy_api_base_url': 'http://localhost:6541'
+        'adhocracy_api_base_url': 'https://adhocracy-prod.policycompass.eu/api'
     },
     'external_resources': {
         'physical_path_phantomCapture': '/home/policycompass/policycompass/policycompass-services/apps/visualizationsmanager/phantomCapture/main.js',

--- a/etc/policycompass/stage/services-settings.py
+++ b/etc/policycompass/stage/services-settings.py
@@ -38,7 +38,7 @@ PC_SERVICES = {
         'updateindexitem' : '/api/v1/searchmanager/updateindexitem',
         'deleteindexitem' : '/api/v1/searchmanager/deleteindexitem',
         'fcm_base_url': 'http://localhost:10080',
-        'adhocracy_api_base_url': 'http://localhost:6541'
+        'adhocracy_api_base_url': 'https://adhocracy-stage.policycompass.eu/api'
     },
     'external_resources': {
         'physical_path_phantomCapture': '/home/policycompass/policycompass/policycompass-services/apps/visualizationsmanager/phantomCapture/main.js',


### PR DESCRIPTION
Otherwise, adhocracy will fail on correct resource paths, as it would
expect resources on http://localhost:6541.

Fixes #302, at least for staging and production. I don't see a reason
why this should happen in local development environment, and I can't
reproduce it there neither.